### PR TITLE
Add video preprocessing and VLC playback

### DIFF
--- a/video_warper.py
+++ b/video_warper.py
@@ -79,7 +79,7 @@ def main():
     info = pygame.display.Info()
     screen_width, screen_height = info.current_w, info.current_h
     print(f"Pygame screen initialized at: {screen_width}x{screen_height}")
-    screen = pygame.display.set_mode((screen_width, screen_height))
+    screen = pygame.display.set_mode((screen_width, screen_height), pygame.FULLSCREEN)
     pygame.display.set_caption("Warped Video Player")
     pygame.mouse.set_visible(False)
 
@@ -103,7 +103,17 @@ def main():
     media = instance.media_new(warped_path)
     player.set_media(media)
     player.audio_set_volume(MAX_VOLUME)
+
+    window_info = pygame.display.get_wm_info().get("window")
+    if window_info:
+        # Direct VLC output to the same window created by pygame
+        try:
+            player.set_xwindow(window_info)
+        except AttributeError:
+            player.set_hwnd(window_info)
+
     player.play()
+    time.sleep(1)  # allow VLC time to start
 
     pir = MotionSensor(MOTION_PIN)
     last_motion = time.time()
@@ -112,7 +122,9 @@ def main():
     clock = pygame.time.Clock()
     font = pygame.font.Font(None, 36)
 
-    while running and player.is_playing():
+    while running:
+        if not player.is_playing():
+            break
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False

--- a/video_warper.py
+++ b/video_warper.py
@@ -3,6 +3,7 @@ import cv2
 import numpy as np
 import json
 import os
+import glob
 import hashlib
 import tempfile
 import time
@@ -11,8 +12,10 @@ from gpiozero import MotionSensor
 
 
 # --- Configuration ---
-VIDEO_PATH = "2.mp4"
+DEFAULT_VIDEO_FILE = "2.mp4"
 CORNERS_FILE = "corners.json"
+USB_MOUNT_POINTS_PREFIX = ["/media/"]
+VIDEO_EXTENSIONS = ["*.mp4", "*.avi", "*.mkv", "*.mov"]
 CACHE_DIR = tempfile.gettempdir()
 MOTION_PIN = 10
 NO_MOTION_TIMEOUT = 2.0
@@ -28,6 +31,20 @@ def load_corners():
    except (FileNotFoundError, json.JSONDecodeError):
        print(f"Warning: Could not read {CORNERS_FILE}. Will try again.")
        return None
+
+
+def find_usb_video_files():
+    """Search USB drives for video files."""
+    for prefix in USB_MOUNT_POINTS_PREFIX:
+        if os.path.exists(prefix):
+            for root_dir in os.listdir(prefix):
+                usb_path = os.path.join(prefix, root_dir)
+                if os.path.isdir(usb_path):
+                    for ext in VIDEO_EXTENSIONS:
+                        files = glob.glob(os.path.join(usb_path, "**", ext), recursive=True)
+                        if files:
+                            return files
+    return []
 
 
 def preprocess_video(video_path, screen_width, screen_height, corners):
@@ -89,9 +106,17 @@ def main():
         pygame.quit()
         return
 
+    usb_videos = find_usb_video_files()
+    video_path = DEFAULT_VIDEO_FILE
+    if usb_videos:
+        video_path = usb_videos[0]
+        print(f"Using USB video: {video_path}")
+    else:
+        print(f"Using default video: {video_path}")
+
     try:
         warped_path = preprocess_video(
-            VIDEO_PATH, screen_width, screen_height, corners
+            video_path, screen_width, screen_height, corners
         )
     except IOError as e:
         print(e)
@@ -159,6 +184,5 @@ def main():
 
 
 if __name__ == "__main__":
-   # TO DO: ADD USB AUTOMOUNT LOGIC!!
-   main()
+    main()
 

--- a/video_warper.py
+++ b/video_warper.py
@@ -8,11 +8,11 @@ import hashlib
 import tempfile
 import time
 import vlc
+import subprocess
 from gpiozero import MotionSensor
 
 
 # --- Configuration ---
-DEFAULT_VIDEO_FILE = "2.mp4"
 CORNERS_FILE = "corners.json"
 USB_MOUNT_POINTS_PREFIX = ["/media/"]
 VIDEO_EXTENSIONS = ["*.mp4", "*.avi", "*.mkv", "*.mov"]
@@ -24,17 +24,18 @@ MAX_VOLUME = 100
 VOLUME_STEP = 5
 
 
-def load_corners():
-   try:
-       with open(CORNERS_FILE, 'r') as f:
-           return json.load(f)
-   except (FileNotFoundError, json.JSONDecodeError):
-       print(f"Warning: Could not read {CORNERS_FILE}. Will try again.")
-       return None
+def load_corners(path=CORNERS_FILE):
+    """Load the corner configuration from a given path."""
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        print(f"Warning: Could not read {path}.")
+        return None
 
 
-def find_usb_video_files():
-    """Search USB drives for video files."""
+def find_usb_video():
+    """Return the first USB mount point with a video file."""
     for prefix in USB_MOUNT_POINTS_PREFIX:
         if os.path.exists(prefix):
             for root_dir in os.listdir(prefix):
@@ -43,8 +44,8 @@ def find_usb_video_files():
                     for ext in VIDEO_EXTENSIONS:
                         files = glob.glob(os.path.join(usb_path, "**", ext), recursive=True)
                         if files:
-                            return files
-    return []
+                            return usb_path, files[0]
+    return None, None
 
 
 def preprocess_video(video_path, screen_width, screen_height, corners):
@@ -100,19 +101,21 @@ def main():
     pygame.display.set_caption("Warped Video Player")
     pygame.mouse.set_visible(False)
 
-    corners = load_corners()
-    if not corners:
-        print("No corner configuration found.")
+    usb_root, video_path = find_usb_video()
+    if not video_path:
+        print("No USB video found. Launching corner setup.")
         pygame.quit()
+        subprocess.run(["python3", "setup_corners.py"])
         return
 
-    usb_videos = find_usb_video_files()
-    video_path = DEFAULT_VIDEO_FILE
-    if usb_videos:
-        video_path = usb_videos[0]
-        print(f"Using USB video: {video_path}")
-    else:
-        print(f"Using default video: {video_path}")
+    corners = load_corners(os.path.join(usb_root, CORNERS_FILE))
+    if not corners:
+        print("No corner configuration found on USB.")
+        pygame.quit()
+        subprocess.run(["python3", "setup_corners.py"])
+        return
+
+    print(f"Using USB video: {video_path}")
 
     try:
         warped_path = preprocess_video(

--- a/video_warper.py
+++ b/video_warper.py
@@ -3,11 +3,22 @@ import cv2
 import numpy as np
 import json
 import os
+import hashlib
+import tempfile
+import time
+import vlc
+from gpiozero import MotionSensor
 
 
 # --- Configuration ---
 VIDEO_PATH = "2.mp4"
 CORNERS_FILE = "corners.json"
+CACHE_DIR = tempfile.gettempdir()
+MOTION_PIN = 10
+NO_MOTION_TIMEOUT = 2.0
+MIN_VOLUME = 30
+MAX_VOLUME = 100
+VOLUME_STEP = 5
 
 
 def load_corners():
@@ -19,87 +30,120 @@ def load_corners():
        return None
 
 
+def preprocess_video(video_path, screen_width, screen_height, corners):
+    """Warp the entire video to a temporary cached file."""
+    cache_key = json.dumps(corners, sort_keys=True) + video_path
+    cache_hash = hashlib.md5(cache_key.encode()).hexdigest()[:8]
+    out_path = os.path.join(
+        CACHE_DIR, f"warped_{os.path.basename(video_path)}_{cache_hash}.mp4"
+    )
+    if os.path.exists(out_path):
+        return out_path
+
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        raise IOError(f"Could not open {video_path}")
+
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    src_w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    src_h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(out_path, fourcc, fps, (screen_width, screen_height))
+
+    src_pts = np.float32([[0, 0], [src_w, 0], [src_w, src_h], [0, src_h]])
+    dst_pts = np.float32([
+        corners["tl"],
+        corners["tr"],
+        corners["br"],
+        corners["bl"],
+    ])
+    matrix = cv2.getPerspectiveTransform(src_pts, dst_pts)
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        warped = cv2.warpPerspective(
+            frame, matrix, (screen_width, screen_height), borderValue=(0, 0, 0)
+        )
+        writer.write(warped)
+
+    cap.release()
+    writer.release()
+    return out_path
+
+
 def main():
-   pygame.init()
-   info = pygame.display.Info()
-   screen_width, screen_height = info.current_w, info.current_h
-   print(f"Pygame screen initialized at: {screen_width}x{screen_height}")
-   screen = pygame.display.set_mode((screen_width, screen_height), pygame.FULLSCREEN)
-   pygame.display.set_caption("Warped Video Player")
-   pygame.mouse.set_visible(False)
+    pygame.init()
+    info = pygame.display.Info()
+    screen_width, screen_height = info.current_w, info.current_h
+    print(f"Pygame screen initialized at: {screen_width}x{screen_height}")
+    screen = pygame.display.set_mode((screen_width, screen_height))
+    pygame.display.set_caption("Warped Video Player")
+    pygame.mouse.set_visible(False)
 
+    corners = load_corners()
+    if not corners:
+        print("No corner configuration found.")
+        pygame.quit()
+        return
 
-   cap = cv2.VideoCapture(VIDEO_PATH)
-   if not cap.isOpened():
-       print(f"Error: Could not open video file at {VIDEO_PATH}")
-       pygame.quit()
-       return
+    try:
+        warped_path = preprocess_video(
+            VIDEO_PATH, screen_width, screen_height, corners
+        )
+    except IOError as e:
+        print(e)
+        pygame.quit()
+        return
 
+    instance = vlc.Instance(" --input-repeat=999999999 -q --no-xlib")
+    player = instance.media_player_new()
+    media = instance.media_new(warped_path)
+    player.set_media(media)
+    player.audio_set_volume(MAX_VOLUME)
+    player.play()
 
-   video_width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-   video_height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    pir = MotionSensor(MOTION_PIN)
+    last_motion = time.time()
 
+    running = True
+    clock = pygame.time.Clock()
+    font = pygame.font.Font(None, 36)
 
-   corners = None
-   running = True
-   clock = pygame.time.Clock()
+    while running and player.is_playing():
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+            if event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_q, pygame.K_ESCAPE):
+                    running = False
 
+        if pir.is_active:
+            last_motion = time.time()
 
-   while running:
-       for event in pygame.event.get():
-           if event.type == pygame.QUIT:
-               running = False
-           if event.type == pygame.KEYDOWN:
-               if event.key == pygame.K_q or event.key == pygame.K_ESCAPE:
-                   running = False
+        current_time = time.time()
+        current_volume = player.audio_get_volume()
 
+        if current_time < last_motion + NO_MOTION_TIMEOUT:
+            if current_volume < MAX_VOLUME:
+                player.audio_set_volume(min(current_volume + VOLUME_STEP, MAX_VOLUME))
+        else:
+            if current_volume > MIN_VOLUME:
+                player.audio_set_volume(max(current_volume - VOLUME_STEP, MIN_VOLUME))
 
-       ret, frame_bgr = cap.read()
-      
-       if not ret:
-           print("End of video. Looping...")
-           cap.release()
-           cap = cv2.VideoCapture(VIDEO_PATH)
-           continue
+        screen.fill((0, 0, 0))
+        status = f"Volume: {player.audio_get_volume()}"
+        text_surface = font.render(status, True, (255, 255, 255))
+        screen.blit(text_surface, (20, 20))
+        pygame.display.flip()
 
+        clock.tick(30)
 
-       loaded_corners = load_corners()
-       if loaded_corners:
-           corners = loaded_corners
-
-
-       if not corners:
-           clock.tick(30)
-           continue
-      
-       src_pts = np.float32([[0, 0], [video_width, 0], [video_width, video_height], [0, video_height]])
-       dst_pts = np.float32([corners['tl'], corners['tr'], corners['br'], corners['bl']])
-      
-       matrix = cv2.getPerspectiveTransform(src_pts, dst_pts)
-      
-       warped_frame_bgr = cv2.warpPerspective(
-           frame_bgr,
-           matrix,
-           (screen_width, screen_height),
-           borderValue=(0, 0, 0)
-       )
-
-
-       frame_rgb = cv2.cvtColor(warped_frame_bgr, cv2.COLOR_BGR2RGB)
-       frame_rgb = frame_rgb.transpose([1, 0, 2])
-      
-       pygame_surface = pygame.surfarray.make_surface(frame_rgb)
-      
-       screen.blit(pygame_surface, (0, 0))
-      
-       pygame.display.flip()
-
-
-       clock.tick(60)
-
-
-   cap.release()
-   pygame.quit()
+    player.stop()
+    player.release()
+    pygame.quit()
 
 
 if __name__ == "__main__":

--- a/vlc_script.py
+++ b/vlc_script.py
@@ -3,7 +3,8 @@ from gpiozero import MotionSensor
 import vlc
 import time
 import os
-import glob # Added for finding files matching a pattern
+import glob  # Added for finding files matching a pattern
+import subprocess
 
 
 pir = MotionSensor(10) # Assuming GPIO10, adjust if different
@@ -16,7 +17,6 @@ last_motion = time.time()
 
 
 # --- Configuration ---
-DEFAULT_VIDEO_FILE = "/home/noorderlicht/video.mp4"
 USB_MOUNT_POINTS_PREFIX = ["/media/"]
 VIDEO_EXTENSIONS = ["*.mp4", "*.avi", "*.mkv", "*.mov"]
 NO_MOTION_TIMEOUT = 2.0
@@ -102,19 +102,17 @@ if __name__ == "__main__":
    try:
        while True:
            usb_videos = find_usb_video_files()
-           video_to_play = DEFAULT_VIDEO_FILE
-
 
            if usb_videos:
                video_to_play = usb_videos[0]
                print(f"💡 USB video: {video_to_play}")
+               play_video(video_to_play)
+               print("--- Loop restarting ---")
+               time.sleep(1)
            else:
-               print(f"💡 default video: {video_to_play}")
-
-
-           play_video(video_to_play)
-           print("--- Loop restarting ---")
-           time.sleep(1)
+               print("⚠️ No USB video found. Starting corner setup.")
+               subprocess.run(["python3", "setup_corners.py"])
+               break
 
 
    except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
- preprocess the entire video using OpenCV
- cache warped videos in `/tmp`
- remove realtime frame processing and play result via VLC
- update main loop with motion sensor based volume control

## Testing
- `python3 -m py_compile video_warper.py`

------
https://chatgpt.com/codex/tasks/task_e_686e2b200d8c8330a88c1a314c22d58e